### PR TITLE
 add checks for dependencies

### DIFF
--- a/internal/check/deps.go
+++ b/internal/check/deps.go
@@ -1,0 +1,121 @@
+package check
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+)
+
+// goModDownload is a variable so tests can stub it.
+var goModDownload = func(dir string) error {
+	cmd := exec.Command("go", "mod", "download", "-json", "all")
+	cmd.Dir = dir
+	return cmd.Run()
+}
+
+type DepsCheck struct {
+	Dir     string
+	Stack   string // "node", "python", or "go"
+	goCheck func(dir string) error
+}
+
+func (c *DepsCheck) Name() string {
+	switch c.Stack {
+	case "node":
+		return "Node dependencies installed"
+	case "python":
+		return "Python dependencies installed"
+	case "go":
+		return "Go dependencies installed"
+	default:
+		return "Project dependencies installed"
+	}
+}
+
+func (c *DepsCheck) Run(_ context.Context) Result {
+	switch c.Stack {
+	case "node":
+		return c.runNode()
+	case "python":
+		return c.runPython()
+	case "go":
+		return c.runGo()
+	default:
+		return Result{
+			Name:    c.Name(),
+			Status:  StatusSkipped,
+			Message: "unknown stack type for dependency check",
+		}
+	}
+}
+
+func (c *DepsCheck) runNode() Result {
+	nodeModules := filepath.Join(c.Dir, "node_modules")
+	if dirExists(nodeModules) {
+		return Result{
+			Name:    c.Name(),
+			Status:  StatusPass,
+			Message: "node_modules directory exists",
+		}
+	}
+
+	return Result{
+		Name:    c.Name(),
+		Status:  StatusFail,
+		Message: "node_modules directory not found",
+		Fix:     "run `npm install` or `pnpm install` to install Node dependencies",
+	}
+}
+
+func (c *DepsCheck) runPython() Result {
+	venv := filepath.Join(c.Dir, "venv")
+	dotVenv := filepath.Join(c.Dir, ".venv")
+
+	if dirExists(venv) || dirExists(dotVenv) {
+		return Result{
+			Name:    c.Name(),
+			Status:  StatusPass,
+			Message: "Python virtual environment directory exists",
+		}
+	}
+
+	return Result{
+		Name:    c.Name(),
+		Status:  StatusFail,
+		Message: "Python virtual environment directory not found",
+		Fix:     "create a virtual environment (e.g. `python -m venv .venv`) and install dependencies with `pip install -r requirements.txt` or equivalent",
+	}
+}
+
+func (c *DepsCheck) runGo() Result {
+	vendorDir := filepath.Join(c.Dir, "vendor")
+	if dirExists(vendorDir) {
+		return Result{
+			Name:    c.Name(),
+			Status:  StatusPass,
+			Message: "vendor directory exists; Go dependencies are vendored",
+		}
+	}
+
+	check := c.goCheck
+	if check == nil {
+		check = goModDownload
+	}
+
+	if err := check(c.Dir); err != nil {
+		return Result{
+			Name:    c.Name(),
+			Status:  StatusFail,
+			Message: fmt.Sprintf("Go module cache not populated: %v", err),
+			Fix:     "run `go mod download` to download Go module dependencies",
+		}
+	}
+
+	return Result{
+		Name:    c.Name(),
+		Status:  StatusPass,
+		Message: "Go module cache is populated",
+	}
+}
+

--- a/internal/check/deps_test.go
+++ b/internal/check/deps_test.go
@@ -1,0 +1,99 @@
+package check
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDepsCheck_Node_PassAndFail(t *testing.T) {
+	dir := t.TempDir()
+	check := &DepsCheck{Dir: dir, Stack: "node"}
+
+	// Pass when node_modules exists
+	if err := os.Mkdir(filepath.Join(dir, "node_modules"), 0o755); err != nil {
+		t.Fatalf("failed to create node_modules: %v", err)
+	}
+	result := check.Run(context.Background())
+	if result.Status != StatusPass {
+		t.Errorf("expected pass when node_modules exists, got %v: %s", result.Status, result.Message)
+	}
+
+	// Fail when node_modules is missing
+	if err := os.RemoveAll(filepath.Join(dir, "node_modules")); err != nil {
+		t.Fatalf("failed to remove node_modules: %v", err)
+	}
+	result = check.Run(context.Background())
+	if result.Status != StatusFail {
+		t.Errorf("expected fail when node_modules missing, got %v: %s", result.Status, result.Message)
+	}
+}
+
+func TestDepsCheck_Python_PassAndFail(t *testing.T) {
+	dir := t.TempDir()
+	check := &DepsCheck{Dir: dir, Stack: "python"}
+
+	// Pass when .venv exists
+	if err := os.Mkdir(filepath.Join(dir, ".venv"), 0o755); err != nil {
+		t.Fatalf("failed to create .venv: %v", err)
+	}
+	result := check.Run(context.Background())
+	if result.Status != StatusPass {
+		t.Errorf("expected pass when .venv exists, got %v: %s", result.Status, result.Message)
+	}
+
+	// Fail when no venv directories exist
+	if err := os.RemoveAll(filepath.Join(dir, ".venv")); err != nil {
+		t.Fatalf("failed to remove .venv: %v", err)
+	}
+	result = check.Run(context.Background())
+	if result.Status != StatusFail {
+		t.Errorf("expected fail when no venv directories, got %v: %s", result.Status, result.Message)
+	}
+}
+
+func TestDepsCheck_Go_PassAndFail(t *testing.T) {
+	dir := t.TempDir()
+
+	// Pass when vendor directory exists
+	check := &DepsCheck{Dir: dir, Stack: "go"}
+	if err := os.Mkdir(filepath.Join(dir, "vendor"), 0o755); err != nil {
+		t.Fatalf("failed to create vendor: %v", err)
+	}
+	result := check.Run(context.Background())
+	if result.Status != StatusPass {
+		t.Errorf("expected pass when vendor exists, got %v: %s", result.Status, result.Message)
+	}
+
+	// When vendor is missing, pass if goCheck succeeds
+	if err := os.RemoveAll(filepath.Join(dir, "vendor")); err != nil {
+		t.Fatalf("failed to remove vendor: %v", err)
+	}
+	check = &DepsCheck{
+		Dir:   dir,
+		Stack: "go",
+		goCheck: func(string) error {
+			return nil
+		},
+	}
+	result = check.Run(context.Background())
+	if result.Status != StatusPass {
+		t.Errorf("expected pass when goCheck succeeds, got %v: %s", result.Status, result.Message)
+	}
+
+	// Fail when goCheck reports an error
+	check = &DepsCheck{
+		Dir:   dir,
+		Stack: "go",
+		goCheck: func(string) error {
+			return errors.New("download failed")
+		},
+	}
+	result = check.Run(context.Background())
+	if result.Status != StatusFail {
+		t.Errorf("expected fail when goCheck fails, got %v: %s", result.Status, result.Message)
+	}
+}
+

--- a/internal/check/registry.go
+++ b/internal/check/registry.go
@@ -12,16 +12,19 @@ func Build(stack detector.DetectedStack) []Check {
 	if stack.Go {
 		cs = append(cs, &BinaryCheck{Binary: "go"})
 		cs = append(cs, &GoVersionCheck{Dir: "."})
+		cs = append(cs, &DepsCheck{Dir: ".", Stack: "go"})
 	}
 	if stack.Node {
 		cs = append(cs, &BinaryCheck{Binary: "node"})
 		cs = append(cs, &BinaryCheck{Binary: "npm"})
 		cs = append(cs, &NodeVersionCheck{Dir: "."})
+		cs = append(cs, &DepsCheck{Dir: ".", Stack: "node"})
 		cs = append(cs, &GitHooksCheck{Dir: ".", Stack: "node"})
 	}
 	if stack.Python {
 		cs = append(cs, &BinaryCheck{Binary: "python3"})
 		cs = append(cs, &BinaryCheck{Binary: "pip"})
+		cs = append(cs, &DepsCheck{Dir: ".", Stack: "python"})
 		cs = append(cs, &GitHooksCheck{Dir: ".", Stack: "python"})
 	}
 	if stack.Java {


### PR DESCRIPTION
closes #9 
### Summary

- Add a DepsCheck to catch missing dependencies right after cloning a repo.
- Node: fail if node_modules/ is missing.
- Python: fail if neither .venv/ nor venv/ exists.
- Go: pass if vendor/ exists; otherwise run go mod download (via goModDownload) and fail if it errors.
- Wire the new check into the Go, Node, and Python stack entries in registry.go.
- Add unit tests covering pass and fail cases for each stack.